### PR TITLE
Add files via upload

### DIFF
--- a/Read Data.txt
+++ b/Read Data.txt
@@ -1,0 +1,4 @@
+> # load foreign package
+> library(foreign)
+> # read in data to R
+> BRFSS2015_Source_Data <- read.xport ("C:/Users/Owner/Documents/R/Data/LLCP2015.XPT")


### PR DESCRIPTION
This code snippet implements the foreign package to read  an XPT file. 

In order to use this snippet you will first need to download and unzip the XPT file from the 
 BRFSS web site at https://www.cdc.gov/brfss/annual_data/annual_2015.html.  

This code snippet assumes that the unzipped  file is located at  (C:/Users/Owner/Documents/R/Data/LLCP2015.XPT).  You will need to change this to reflect the actual storage location on your system.

The outcome is a data file  named BRFSS2015_Source_Data.